### PR TITLE
Update README.md: fix spelling of `majority`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a very opinionated abstraction over amqplib to help simplify certain com
  * Gracefully handle re-connections
  * Automatically re-define all topology on re-connection
  * Automatically re-send any unconfirmed messages on re-connection
- * Support the majort of RabbitMQ's extensions
+ * Support the majority of RabbitMQ's extensions
  * Handle batching of acknowledgements and rejections
  * Topology & configuration via the JSON configuration method (thanks to @JohnDMathis!)
 


### PR DESCRIPTION
I assume you meant to use the word 'majority' when referring to RabbitMQ extensions in the README. I corrected the spelling.
