### PR TITLE
added editorconfig file, to specify tabs for indent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.js]
+indent_style = tab
+indent_size = 2


### PR DESCRIPTION
seeing that i got the tabs vs spaces wrong in my previous pull request, and realizing that my editor (vim) is set up to automatically replace tabs with spaces, i thought it would be a good idea to fix this with the use of editorconfig http://editorconfig.org/

having this in place will ensure that i don't break the tab formatting again, and will help others that want to contribute, as well. you just need to install a plugin for your editor (found at the url noted) and you're good to go.

I've added a `.editorconfig` file to the project, to specify tabs with a tab size of 2 as the default for .js files. I wasn't sure what size you prefer, so I stuck with what is typical of js projects that I work with. i'll adjust the tab size to whatever you want, though. 