### PR TITLE
0.2.1 - Critical bug fix, improved promises use, dependency and README updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## 0.2.*
 
+### 0.2.1
+
+Special thanks to @neverfox for finding and reportig #38 & #39 - both serious problems and very difficult to find/reproduce in any kind of automated test.
+
+ * #38, #39 - I/O getting blocked when publishing at high frequencies (think for/while loops).
+ 	* Removed one-time `failed` event handler from publish call
+ 	* Cache reject callbacks from publish
+ 	* On publish confirmation, remove reject from deferred array
+ 	* On exchange connection failure, invoke all rejects in deferred array
+ * #37 - document use of close and closeAll calls
+ * Correct improper use of .then( null, ... ) which was creating additional promises.
+ * Update whistlepunk version
+ * Include biggulp to simplify the gulpfile (yay?)
+
 ### 0.2.0
 
  * Add logging support via whistlepunk

--- a/README.md
+++ b/README.md
@@ -329,6 +329,17 @@ To establish a connection with all settings in place and ready to go call config
 	} );
 ```
 
+## Closing Connections
+Wascally will attempt to resolve all outstanding publishes and recieved messages (ack/nack/reject) before closing the channels and connection. If you would like to defer certain actions until after everything has been safely resolved, then use the promise returned from either close call.
+
+> !!! CAUTION !!! - using reset is dangerous. All topology associated with the connection will be removed meaning wasclly will not be able to re-establish it all should you decide to reconnect.
+
+### close( [connectionName], [reset] )
+Closes the connection, optionall resetting all previously defined topology for the connection. The `connectionName` uses `default` if one is not provided.
+
+### closeAll( [reset] )
+Closes __all__ connections, optionally resetting the topology for all of them.
+
 ## AMQPS, SSL/TLS Support
 Providing the following configuration options setting the related environment varibles will cause wascally to attempt connecting via AMQPS. For more details about which settings perform what role, refer to the amqplib's page on [SSL](http://www.squaremobius.net/amqp.node/doc/ssl.html).
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,98 +1,12 @@
 var gulp = require( 'gulp' );
-var mocha = require( 'gulp-mocha' );
-var processhost = require( 'processhost' )();
-var exec = require( 'child_process' ).exec;
-var istanbul = require( 'gulp-istanbul' );
-var open = require( 'open' ); //jshint ignore : line
+var bg = require( 'biggulp' )( gulp );
 
-function cover( done ) {
-	gulp.src( [ './src/**/*.js' ] )
-		.pipe( istanbul() )
-		.pipe( istanbul.hookRequire() )
-		.on( 'finish', function() {
-			done( runSpecs() );
-		} );
-}
-
-function runSpecs() { // jshint ignore : line
-	return gulp.src( [ './spec/behavior/*.spec.js', './spec/integration/integration.spec.js' ], { read: false } )
-		.pipe( mocha( { reporter: 'spec' } ) );
-}
-
-function writeReport( cb, openBrowser, tests ) {
-	tests
-		.on( 'error', function( e ) {
-			console.log( 'error occurred during testing', e.stack );
-		} )
-		.pipe( istanbul.writeReports() )
-		.on( 'end', function() {
-			if ( openBrowser ) {
-				open( './coverage/lcov-report/index.html' );
-			}
-			cb();
-		} );
-}
-
-gulp.task( 'continuous-coverage', function( cb ) {
-	cover( writeReport.bind( undefined, cb, false ) );
-} );
-
-gulp.task( 'continuous-test', function() {
-	return runSpecs()
-		.on( 'end', function() {
-			// console.log( process._getActiveRequests() );
-			// console.log( process._getActiveHandles() );
-		} );
-} );
-
-gulp.task( 'coverage', function( cb ) {
-	cover( writeReport.bind( undefined, cb, true ) );
-} );
+gulp.task( 'coverage', bg.withCoverage() );
 
 gulp.task( 'coverage-watch', function() {
-	gulp.watch( [ './src/**/*', './spec/**/*' ], [ 'continuous-coverage' ] );
+	bg.watch( [ 'coverage' ] );
 } );
 
-gulp.task( 'test', function() {
-	return runSpecs()
-		.on( 'end', process.exit.bind( process, 0 ) )
-		.on( 'error', process.exit.bind( process, 1 ) );
-} );
+gulp.task( 'show-coverage', bg.showCoverage() );
 
-gulp.task( 'sleep-and-test', function() {
-	exec( "sleep 2", function( error, stdout, stderr ) {
-		runSpecs()
-			.on( 'end', function() {
-				// console.log( process._getActiveRequests() );
-				// console.log( process._getActiveHandles() );
-			} );
-	} );
-} );
-
-gulp.task( 'host-watch', function() {
-	gulp.watch( [ './src/**', './spec/**' ], [ 'restart', 'test' ] );
-} );
-
-gulp.task( 'restart', function() {
-	console.log( 'restarting application' );
-	processhost.restart();
-} );
-
-gulp.task( 'host', function() {
-	processhost.startProcess( 'rabbit', {
-		command: 'rabbitmq-server',
-		args: [],
-		stdio: 'inherit'
-	} );
-} );
-
-gulp.task( 'test-watch', function() {
-	gulp.watch( [ './src/**/*', './spec/**/*' ], [ 'continuous-test' ] );
-} );
-
-gulp.task( 'default', [ 'continuous-coverage', 'coverage-watch' ], function() {} );
-
-// gulp.task( 'specs', [ 'continuous-test', 'test-watch' ], function() {} );
-gulp.task( 'specs', [ 'continuous-test', 'test-watch' ], function() {} );
-
-gulp.task( 'server', [ 'host', 'host-watch', 'sleep-and-test' ], function() {} );
+gulp.task( 'default', [ 'coverage', 'coverage-watch' ], function() {} );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wascally",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Abstractions to simplify working with the wascally wabbitMQ",
   "main": "src/index.js",
   "repository": "https://github.com/leankit-labs/wascally",
@@ -35,11 +35,7 @@
   "license": "MIT License - http://opensource.org/licenses/MIT",
   "devDependencies": {
     "gulp": "~3.8.1",
-    "gulp-istanbul": "^0.5.0",
-    "gulp-mocha": "~0.4.1",
-    "istanbul": "^0.3.5",
-    "open": "0.0.5",
-    "processhost": "~0.1.6",
+    "biggulp": "0.*.*",
     "should": "~3.1.3",
     "sinon": "^1.12.2"
   },
@@ -50,8 +46,8 @@
     "machina": "^0.3.6",
     "monologue.js": "~0.1.4",
     "node-uuid": "^1.4.1",
-    "postal": "1.0.0",
+    "postal": "1.0.*",
     "when": "~3.0.0",
-    "whistlepunk": "0.0.1"
+    "whistlepunk": "0.2.0"
   }
 }

--- a/spec/behavior/configuration.spec.js
+++ b/spec/behavior/configuration.spec.js
@@ -75,13 +75,9 @@ describe( 'Configuration', function() {
 				.withArgs( config.exchanges )
 				.returns( when.reject( new Error( 'Not feelin\' it today' ) ) );
 			connectionMock.expects( 'configureQueues' )
-				.once()
-				.withArgs( config.queues )
-				.returns( when( true ) );
+				.never();
 			connectionMock.expects( 'configureBindings' )
-				.once()
-				.withArgs( config.bindings, 'test' )
-				.returns( when( true ) );
+				.never();
 			require( '../../src/config' )( Broker );
 
 			var broker = new Broker( connection );
@@ -125,9 +121,7 @@ describe( 'Configuration', function() {
 				.withArgs( config.queues )
 				.returns( when.reject( new Error( 'Not feelin\' it today' ) ) );
 			connectionMock.expects( 'configureBindings' )
-				.once()
-				.withArgs( config.bindings, 'test' )
-				.returns( when( true ) );
+				.never();
 			require( '../../src/config' )( Broker );
 
 			var broker = new Broker( connection );

--- a/spec/integration/integration.spec.js
+++ b/spec/integration/integration.spec.js
@@ -139,9 +139,6 @@ describe( 'Integration Test Suite', function() {
 						}
 					]
 				} )
-					.then( function() {
-						console.log( 'YAY I AM STILL DUM!' );
-					} )
 					.then( null, function( err ) {
 						error = err;
 						done();

--- a/src/amqp/connection.js
+++ b/src/amqp/connection.js
@@ -89,19 +89,19 @@ Adapter.prototype.connect = function() {
 		attempt = function() {
 			var nextUri = this.getNextUri();
 			log.info( 'Attempting connection to %s (%s)', this.name, nextUri );
+			function onConnection( connection ) {
+				log.info( 'Connected to %s (%s)', this.name, nextUri );
+				resolve( connection );
+			}
+			function onConnectionError( err ) {
+				log.info( 'Failed to connect to %s (%s) with', this.name, nextUri, err );
+				attempted.push( nextUri );
+				this.bumpIndex();
+				attempt( err );
+			}
 			if ( _.indexOf( attempted, nextUri ) < 0 ) {
-				var onConnection = function( connection ) {
-					log.info( 'Connected to %s (%s)', this.name, nextUri );
-					resolve( connection );
-				}.bind( this );
-				var onConnectionError = function( err ) {
-					log.info( 'Failed to connect to %s (%s) with', this.name, nextUri, err );
-					attempted.push( nextUri );
-					this.bumpIndex();
-					attempt( err );
-				}.bind( this );
 				amqp.connect( nextUri, this.options )
-					.then( onConnection, onConnectionError );
+					.then( onConnection.bind( this ), onConnectionError.bind( this ) );
 			} else {
 				log.info( 'Cannot connect to %s - all endpoints failed', this.name );
 				reject( 'No endpoints could be reached' );

--- a/src/amqp/promiseMachine.js
+++ b/src/amqp/promiseMachine.js
@@ -16,12 +16,12 @@ module.exports = function( factory, target, release, disposalEvent ) {
 		waitMax: 5000,
 		_acquire: function() {
 			this.emit( 'acquiring' );
-			var onAcquisitionError = function( err ) {
+			function onAcquisitionError( err ) {
 				log.debug( 'Resource acquisition failed with \'%s\'', err );
 				this.emit( 'failed', err );
 				this.handle( 'failed' );
-			}.bind( this );
-			var onAcquired = function( o ) {
+			}
+			function onAcquired( o ) {
 				this.item = o;
 				this.waitInterval = 0;
 				if ( this.item.on ) {
@@ -34,15 +34,15 @@ module.exports = function( factory, target, release, disposalEvent ) {
 					}.bind( this ) );
 				}
 				this.transition( 'acquired' );
-			}.bind( this );
-			var onException = function( ex ) {
+			}
+			function onException( ex ) {
 				log.debug( 'Resource acquisition failed with \'%s\'', ex );
 				this.emit( 'failed', ex );
 				this.handle( 'failed' );
-			};
+			}
 			factory()
-				.then( onAcquired, onAcquisitionError )
-				.catch( onException );
+				.then( onAcquired.bind( this ), onAcquisitionError.bind( this ) )
+				.catch( onException.bind( this ) );
 		},
 		_dispose: function() {
 			if ( this.item ) {

--- a/src/amqp/promiseMachine.js
+++ b/src/amqp/promiseMachine.js
@@ -16,31 +16,33 @@ module.exports = function( factory, target, release, disposalEvent ) {
 		waitMax: 5000,
 		_acquire: function() {
 			this.emit( 'acquiring' );
+			var onAcquisitionError = function( err ) {
+				log.debug( 'Resource acquisition failed with \'%s\'', err );
+				this.emit( 'failed', err );
+				this.handle( 'failed' );
+			}.bind( this );
+			var onAcquired = function( o ) {
+				this.item = o;
+				this.waitInterval = 0;
+				if ( this.item.on ) {
+					this.disposeHandle = this.item.once( disposalEvent, function( /* err */ ) {
+						this.emit( 'lost' );
+						this.transition( 'released' );
+					}.bind( this ) );
+					this.item.once( 'error', function( /* err */ ) {
+						this.transition( 'failed' );
+					}.bind( this ) );
+				}
+				this.transition( 'acquired' );
+			}.bind( this );
+			var onException = function( ex ) {
+				log.debug( 'Resource acquisition failed with \'%s\'', ex );
+				this.emit( 'failed', ex );
+				this.handle( 'failed' );
+			};
 			factory()
-				.then( function( o ) {
-					this.item = o;
-					this.waitInterval = 0;
-					if ( this.item.on ) {
-						this.disposeHandle = this.item.once( disposalEvent, function( /* err */ ) {
-							this.emit( 'lost' );
-							this.transition( 'released' );
-						}.bind( this ) );
-						this.item.once( 'error', function( /* err */ ) {
-							this.transition( 'failed' );
-						}.bind( this ) );
-					}
-					this.transition( 'acquired' );
-				}.bind( this ) )
-				.then( null, function( err ) {
-					log.debug( 'Resource acquisition failed with \'%s\'', err );
-					this.emit( 'failed', err );
-					this.handle( 'failed' );
-				}.bind( this ) )
-				.catch( function( ex ) {
-					log.debug( 'Resource acquisition failed with \'%s\'', ex );
-					this.emit( 'failed', ex );
-					this.handle( 'failed' );
-				} );
+				.then( onAcquired, onAcquisitionError )
+				.catch( onException );
 		},
 		_dispose: function() {
 			if ( this.item ) {

--- a/src/amqp/queue.js
+++ b/src/amqp/queue.js
@@ -170,7 +170,6 @@ function subscribe( channelName, channel, topology, messages, options ) {
 		} else {
 			dispatch.publish( raw.type, raw, function( data ) {
 				if ( data.activated && !ops.noAck ) {
-					;
 					messages.addMessage( ops.message );
 				} else {
 					unhandledLog.warn( 'Message of %s on queue %s - %s was not processed by any registered handlers',

--- a/src/config.js
+++ b/src/config.js
@@ -12,37 +12,41 @@ module.exports = function( Broker ) {
 		var emit = this.emit;
 		return when.promise( function( resolve, reject ) {
 
-			var onExchangeError = function( err ) {
+			function onExchangeError( err ) {
 				log.error( 'Configuration of %s failed due to an error in one or more exchange settings: %s', connection.name, err );
 				reject( err );
-			}.bind( this );
-			var createExchanges = function() {
-				connection.configureExchanges( config.exchanges )
-					.then( createQueues, onExchangeError );
-			}.bind( this );
+			}
 
-			var onQueueError = function( err ) {
+			function onQueueError( err ) {
 				log.error( 'Configuration of %s failed due to an error in one or more queue settings: %s', connection.name, err );
 				reject( err );
-			}.bind( this );
-			var createQueues = function() {
-				connection.configureQueues( config.queues )
-					.then( createBindings, onQueueError );
-			}.bind( this );
+			}
 
-			var onBindingError = function( err ) {
+			function onBindingError( err ) {
 				log.error( 'Configuration of %s failed due to an error in one or more bindings: %s', connection.name, err );
 				reject( err );
-			}.bind( this );
-			var createBindings = function() {
+			}
+
+			function createExchanges() {
+				connection.configureExchanges( config.exchanges )
+					.then( createQueues, onExchangeError );
+			}
+
+			function createQueues() {
+				connection.configureQueues( config.queues )
+					.then( createBindings, onQueueError );
+			}
+
+			function createBindings() {
 				connection.configureBindings( config.bindings, connection.name )
 					.then( finish, onBindingError );
-			}.bind( this );
+			}
 
-			var finish = function() {
+			function finish() {
 				emit( connection.name + '.connection.configured', connection );
 				resolve();
-			};
+			}
+
 			connection = this.addConnection( config.connection );
 			createExchanges();
 		}.bind( this ) );


### PR DESCRIPTION
Special thanks to @neverfox for finding and reporting #38 & #39.

* #38, #39 - I/O getting blocked when publishing at high frequencies (think for/while loops).
 	* Removed one-time `failed` event handler from publish call
 	* Cache reject callbacks from publish
 	* On publish confirmation, remove reject from deferred array
 	* On exchange connection failure, invoke all rejects in deferred array
 * #37 - document use of close and closeAll calls
 * Correct improper use of .then( null, ... ) which was creating additional promises.
 * Update whistlepunk version
 * Include biggulp to simplify the gulpfile (yay?)