### PR TITLE
[WSY-45] Check the `port` options before defaulting

### DIFF
--- a/src/amqp/connection.js
+++ b/src/amqp/connection.js
@@ -36,7 +36,7 @@ function trim( x ) {
 
 var Adapter = function( parameters ) {
 	var serverList = getOption( parameters, 'RABBIT_BROKER' ) || getOption( parameters, 'server', 'localhost' );
-	var portList = getOption( parameters, 'RABBIT_PORT', 5672 );
+	var portList = getOption( parameters, 'RABBIT_PORT' ) || getOption( parameters, 'port', 5672 );
 
 	this.name = parameters ? ( parameters.name || 'default' ) : 'default';
 	this.connectionIndex = 0;


### PR DESCRIPTION
Connection adapter was checking `RABBIT_PORT` and
immediately falling back to 5672 before checking the
documented `port` option.