### PR TITLE
noBatch: allow a queue to run without batching ack/nack

### DIFF
--- a/spec/integration/configuration.js
+++ b/spec/integration/configuration.js
@@ -58,8 +58,7 @@ module.exports = {
 		{
 			name: 'wascally-ex.no-batch',
 			type: 'direct',
-			autoDelete: true,
-			limit: 5
+			autoDelete: true
 		}
 	],
 
@@ -125,7 +124,8 @@ module.exports = {
 		{
 			name: 'wascally-q.no-batch',
 			autoDelete: true,
-			subscribe: true
+			subscribe: true,
+			limit: 5
 		}
 	],
 

--- a/spec/integration/configuration.js
+++ b/spec/integration/configuration.js
@@ -125,6 +125,7 @@ module.exports = {
 			name: 'wascally-q.no-batch',
 			autoDelete: true,
 			subscribe: true,
+			noBatch: true,
 			limit: 5
 		}
 	],

--- a/spec/integration/configuration.js
+++ b/spec/integration/configuration.js
@@ -54,6 +54,12 @@ module.exports = {
 			arguments: {
 				'hash-header': 'CorrelationId'
 			}
+		},
+		{
+			name: 'wascally-ex.no-batch',
+			type: 'direct',
+			autoDelete: true,
+			limit: 5
 		}
 	],
 
@@ -115,6 +121,11 @@ module.exports = {
 			name: 'wascally-q.hashed4',
 			autoDelete: true,
 			subscribe: true
+		},
+		{
+			name: 'wascally-q.no-batch',
+			autoDelete: true,
+			subscribe: true
 		}
 	],
 
@@ -173,6 +184,10 @@ module.exports = {
 			exchange: 'wascally-ex.consistent-hash',
 			target: 'wascally-q.hashed4',
 			keys: '100'
+		},
+		{
+			exchange: 'wascally-ex.no-batch',
+			target: 'wascally-q.no-batch'
 		}
 	]
 };

--- a/spec/integration/integration.spec.js
+++ b/spec/integration/integration.spec.js
@@ -411,7 +411,7 @@ describe( 'Integration Test Suite', function() {
 		var messagesToSend, harness;
 
 		before( function( done ) {
-			this.timeout( 3000 );
+			this.timeout( 6000 );
 
 			messagesToSend = 10;
 			harness = harnessFn( done, messagesToSend );
@@ -431,11 +431,6 @@ describe( 'Integration Test Suite', function() {
 					routingKey: ''
 				} );
 			};
-
-			// don't fail for timeout
-			setTimeout(function(){
-				done();
-			}, 2000);
 		} );
 
 		it( 'should receive all messages', function() {

--- a/spec/integration/integration.spec.js
+++ b/spec/integration/integration.spec.js
@@ -412,11 +412,11 @@ describe( 'Integration Test Suite', function() {
 
 		before( function( done ) {
 			this.timeout( 3000 );
+
 			messagesToSend = 10;
-
 			harness = harnessFn( done, messagesToSend );
-
 			var messageCount = 0;
+
 			harness.handle( 'no.batch', function(message){
 				if ( messageCount > 0 ) {
 					message.ack();

--- a/spec/integration/integration.spec.js
+++ b/spec/integration/integration.spec.js
@@ -407,6 +407,36 @@ describe( 'Integration Test Suite', function() {
 		} );
 	} );
 
+	describe( 'with noBatch enabled', function() {
+		var messagesToSend, harness;
+
+		before( function( done ) {
+			messagesToSend = 10;
+
+			harness = harnessFn( done, messagesToSend );
+
+			var messageCount = 0;
+			harness.handle( 'no.batch', function(message){
+				if ( messageCount > 0 ) {
+					message.ack();
+				}
+				messageCount += 1;
+			});
+
+			for(var i=0; i< messagesToSend; i++){
+				rabbit.publish( 'wascally-ex.no-batch', {
+					type: 'no.batch',
+					body: 'message ' + i,
+					routingKey: ''
+				} );
+			};
+		} );
+
+		it( 'should receive all messages', function() {
+			harness.received.length.should.equal(messagesToSend);
+		} );
+	} );
+
 	after( function() {
 		rabbit.deleteExchange( 'wascally-ex.deadend' ).then( function() {} );
 		return rabbit.closeAll();

--- a/spec/integration/integration.spec.js
+++ b/spec/integration/integration.spec.js
@@ -411,6 +411,7 @@ describe( 'Integration Test Suite', function() {
 		var messagesToSend, harness;
 
 		before( function( done ) {
+			this.timeout( 3000 );
 			messagesToSend = 10;
 
 			harness = harnessFn( done, messagesToSend );
@@ -430,6 +431,11 @@ describe( 'Integration Test Suite', function() {
 					routingKey: ''
 				} );
 			};
+
+			// don't fail for timeout
+			setTimeout(function(){
+				done();
+			}, 2000);
 		} );
 
 		it( 'should receive all messages', function() {

--- a/src/amqp/queue.js
+++ b/src/amqp/queue.js
@@ -182,13 +182,6 @@ function subscribe( channelName, channel, topology, messages, options ) {
 	var shouldAck = !options.noAck;
 	var shouldBatch = !options.noBatch;
 
-	console.log("-------------------------------------");
-	console.log("-------------------------------------");
-	console.log("should ack?", shouldAck);
-	console.log("should batch?", shouldBatch);
-	console.log("-------------------------------------");
-	console.log("-------------------------------------");
-
 	if ( shouldAck && shouldBatch ) {
 		messages.listenForSignal();
 	}

--- a/src/amqp/queue.js
+++ b/src/amqp/queue.js
@@ -202,13 +202,12 @@ function subscribe( channelName, channel, topology, messages, options ) {
 		} else {
 			dispatch.publish( raw.type, raw, function( data ) {
 				var handled;
-				if ( data.activated && (shouldAck && shouldBatch) ) {
-					messages.addMessage( ops.message );
-					handled = true;
-				}
 
-				if (data.activated && !shouldBatch){
+				if( data.activated ) {
 					handled = true;
+					if( shouldAck && shouldBatch ) {
+						messages.addMessage( ops.message );
+					}
 				}
 
 				if (!handled){


### PR DESCRIPTION
Per #47, this pull request adds the ability to run a queue without batching ack/nack calls for a message.

The functionality appears to be working in both the integration test that I wrote, as well as in testing my system where I need this feature. 

There is probably some work left to be done here, but I wanted to open the PR now so that we can start reviewing it and get things squared away for this to be merged.

Notably, one of the things to be done is documentation. There is now a `noBatch` option for queue definitions.

```js
{
  queues: [{
    name: "some.q",
    limit: 5,
    noBatch: true
  }]
}
```

Enabling the `noBatch` option will ack / nack each message individually, instead of batching them up.