### PR TITLE
replyQueue false cause publish error

### DIFF
--- a/src/topology.js
+++ b/src/topology.js
@@ -49,7 +49,7 @@ var Topology = function( connection, options, unhandledStrategies ) {
 	}
 	if ( replyQueueName.toLowerCase() === 'rabbitmq' ) {
 		this.replyQueue = rabbitReplyTo;
-	} else if ( _.has( options, 'replyQueue' ) ) {
+	} else if ( _.has( options, 'replyQueue' ) && options.replyQueue ) {
 		this.replyQueue = userReplyTo;
 	} else {
 		this.replyQueue = autoReplyTo;


### PR DESCRIPTION
when replyQueue is set to false,
_.has( options, 'replyQueue' ) => true
but
```
var userReplyTo = _.isObject( options.replyQueue ) ? options.replyQueue : { name: options.replyQueue, autoDelete: true, subscribe: true };
```
userReplyTo => { name: false, autoDelete: true, subscribe: true }
crashes because name is expected to be a string