### PR TITLE
Fix publish defect. Add URI to connection. Improvements around connection cleanup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## 0.2.*
 
+### 0.2.5
+
+ * #65 - Bug Fix: setting replyQueue to false caused publish to fail silently.
+ * #63 - Add `uri` property to connection object emitted for 'connected' event.
+ * #61 - Bug Fix: correct SSL URIs - thanks, @longplay
+ * Improvements to connection clean up (specifically around resolving outstanding messages on queues)
+ * ConnectionFSM - Only emit 'connected' when establishing a new connection, use 'already-connected' otherwise.
+
 ### 0.2.4
 Thanks to @dvideby0 and @neverfox for identifying and providing code to help reproduce bugs #39 and #57.
 

--- a/spec/integration/alt-configuration.js
+++ b/spec/integration/alt-configuration.js
@@ -1,0 +1,34 @@
+module.exports = {
+	connection: {
+		name: 'default',
+		user: 'guest',
+		pass: 'guest',
+		server: '127.0.0.1',
+		port: 5672,
+		vhost: '%2f',
+		replyQueue: false
+	},
+	exchanges: [
+		{
+			name: 'noreply-ex.direct',
+			type: 'direct',
+			autoDelete: true
+		}
+	],
+
+	queues: [
+		{
+			name: 'noreply-q.direct',
+			autoDelete: true,
+			subscribe: true
+		}
+	],
+
+	bindings: [
+		{
+			exchange: 'noreply-ex.direct',
+			target: 'noreply-q.direct',
+			keys: ''
+		}
+	]
+};

--- a/src/ackBatch.js
+++ b/src/ackBatch.js
@@ -51,7 +51,7 @@ AckBatch.prototype._ackOrNackSequence = function() {
 				this[ call ]( sequenceEnd, true );
 			}
 		}
-	} catch (err) {
+	} catch ( err ) {
 		log.error( 'An exception occurred while trying to resolve ack/nack sequence on %s - %s: %s', this.name, this.connectionName, err.stack );
 	}
 };

--- a/src/amqp/connection.js
+++ b/src/amqp/connection.js
@@ -90,6 +90,7 @@ Adapter.prototype.connect = function() {
 			var nextUri = this.getNextUri();
 			log.info( 'Attempting connection to %s (%s)', this.name, nextUri );
 			function onConnection( connection ) {
+				connection.uri = nextUri;
 				log.info( 'Connected to %s (%s)', this.name, nextUri );
 				resolve( connection );
 			}

--- a/src/amqp/exchange.js
+++ b/src/amqp/exchange.js
@@ -41,7 +41,7 @@ function publish( channel, options, topology, log, message ) {
 		contentType: 'application/json',
 		contentEncoding: 'utf8',
 		correlationId: message.correlationId || '',
-		replyTo: message.replyTo || topology.replyQueue.name,
+		replyTo: message.replyTo || topology.replyQueue.name || '',
 		messageId: message.messageId || message.id || '',
 		timestamp: message.timestamp,
 		appId: message.appId || '',

--- a/src/connectionFsm.js
+++ b/src/connectionFsm.js
@@ -54,6 +54,9 @@ var Connection = function( options, connectionFn, channelFn ) {
 				this.once( 'connected', function() {
 					resolve();
 				} );
+				this.once( 'already-connected', function() {
+					resolve();
+				} );
 				this.handle( 'connect' );
 			}.bind( this ) );
 		},
@@ -120,7 +123,7 @@ var Connection = function( options, connectionFn, channelFn ) {
 						this.emit( 'reconnected' );
 					}
 					this.reconnected = true;
-					this.emit( 'connected' );
+					this.emit( 'connected', connection );
 				},
 				'failed': function( err ) {
 					this.emit( 'failed', err );
@@ -133,7 +136,7 @@ var Connection = function( options, connectionFn, channelFn ) {
 					this.transition( 'closing' );
 				},
 				'connect': function() {
-					this.emit( 'connected' );
+					this.emit( 'already-connected', connection );
 				}
 			},
 			'closed': {

--- a/src/exchangeFsm.js
+++ b/src/exchangeFsm.js
@@ -67,10 +67,15 @@ var Channel = function( options, connection, topology, channelFn ) {
 		destroy: function() {
 			exLog.debug( 'Destroy called on exchange %s - %s (%d messages pending)', this.name, connection.name, this.published.count() );
 			this.transition( 'destroying' );
-			return this.channel.destroy()
-				.then( function() {
-					this.transition( 'destroyed' );
-				}.bind( this ) );
+			if ( this.channel ) {
+				return this.channel.destroy()
+					.then( function() {
+						this.transition( 'destroyed' );
+					}.bind( this ) );
+			} else {
+				this.transition( 'destroyed' );
+				return when.resolve();
+			}
 		},
 
 		publish: function( message ) {

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,8 @@ Broker.prototype.addConnection = function( options ) {
 	if ( !this.connections[ name ] ) {
 		var connection = connectionFn( options || {} );
 		var topology = topologyFn( connection, options || {}, unhandledStrategies );
-		connection.on( 'connected', function() {
+		connection.on( 'connected', function( state ) {
+			connection.uri = state.item.uri;
 			this.emit( 'connected', connection );
 			this.emit( connection.name + '.connection.opened', connection );
 		}.bind( this ) );
@@ -204,6 +205,10 @@ Broker.prototype.request = function( exchangeName, options, connectionName ) {
 		} );
 		this.publish( exchangeName, options );
 	}.bind( this ) );
+};
+
+Broker.prototype.reset = function() {
+	this.connections = {};
 };
 
 Broker.prototype.setAckInterval = function( interval ) {


### PR DESCRIPTION
 * #65 - Bug Fix: setting replyQueue to false caused publish to fail silently.
 * #63 - Add `uri` property to connection object emitted for 'connected' event.
 * #61 - Bug Fix: correct SSL URIs - thanks, @longplay
 * Improvements to connection clean up (specifically around resolving outstanding messages on queues)
 * ConnectionFSM - Only emit 'connected' when establishing a new connection, use 'already-connected' otherwise.