### PR TITLE
Update dependencies. Prefer defer. Bug fix for queue and exchange destroy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.2.*
 
+### 0.2.6
+ * Bug fix - calling destroy on a queue or exchange should defer until they are in ready state.
+ * Update machine and monologue versions
+ * Remove when.promise and event handles in favor of deferred promises and transitions
+
 ### 0.2.5
 
  * #65 - Bug Fix: setting replyQueue to false caused publish to fail silently.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,4 +9,18 @@ gulp.task( 'coverage-watch', function() {
 
 gulp.task( 'show-coverage', bg.showCoverage() );
 
+gulp.task( 'continuous-test', function() {
+	return bg.test();
+} );
+
+gulp.task( 'test-watch', function() {
+	bg.watch( [ 'continuous-test' ] );
+} );
+
+gulp.task( 'test-and-exit', function() {
+	return bg.testOnce();
+} );
+
 gulp.task( 'default', [ 'coverage', 'coverage-watch' ], function() {} );
+gulp.task( 'test', [ 'continuous-test', 'test-watch' ], function() {} );
+gulp.task( 'build', [ 'test-and-exit' ] );

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "wascally",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Abstractions to simplify working with the wascally wabbitMQ",
   "main": "src/index.js",
   "repository": "https://github.com/leankit-labs/wascally",
   "scripts": {
-    "test": "gulp coverage"
+    "test": "gulp test-and-exit"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
@@ -46,20 +46,21 @@
       "url": "http://blog.bispooliveira.de"
     }
   ],
-  "license": "MIT License - http://opensource.org/licenses/MIT",
+  "license": "MIT",
   "devDependencies": {
-    "gulp": "~3.8.1",
     "biggulp": "0.*.*",
     "chai": "^2.0.0",
     "chai-as-promised": "^4.2.0",
-    "sinon": "^1.12.2"
+    "gulp": "~3.8.1",
+    "sinon": "^1.12.2",
+    "sinon-as-promised": "^3.0.0"
   },
   "dependencies": {
     "amqplib": "~0.3.0",
     "debug": "^2.1.1",
     "lodash": "~2.4.1",
-    "machina": "^0.3.6",
-    "monologue.js": "~0.1.4",
+    "machina": "~1.0.1",
+    "monologue.js": "~0.3.3",
     "node-uuid": "^1.4.1",
     "postal": "1.0.*",
     "when": "~3.0.0",

--- a/spec/behavior/connection.spec.js
+++ b/spec/behavior/connection.spec.js
@@ -96,7 +96,7 @@ describe( 'Connection FSM', function() {
 				before( function( done ) {
 					connection.on( 'failed', function() {
 						done();
-					} );
+					} ).once();
 					connection.on( 'acquiring', function() {
 						monad.raise( 'failed', new Error( 'bummer' ) );
 					} );

--- a/spec/behavior/exchangeFsm.spec.js
+++ b/spec/behavior/exchangeFsm.spec.js
@@ -46,7 +46,7 @@ describe( 'Exchange FSM', function() {
 			exchange.on( 'failed', function( err ) {
 				error = err;
 				done();
-			} );
+			} ).once();
 		} );
 
 		it( 'should have failed with an error', function() {
@@ -90,10 +90,10 @@ describe( 'Exchange FSM', function() {
 			exchange.on( 'failed', function( err ) {
 				error = err;
 				done();
-			} );
+			} ).once();
 			exchange.on( 'defined', function() {
 				done();
-			} );
+			} ).once();
 		} );
 
 		it( 'should not have failed', function() {
@@ -134,10 +134,10 @@ describe( 'Exchange FSM', function() {
 				exchange.on( 'failed', function( err ) {
 					error = err;
 					done();
-				} );
+				} ).once();
 				exchange.on( 'defined', function() {
 					done();
-				} );
+				} ).once();
 
 				ch.factory().channel.raise( 'released' );
 			} );
@@ -186,7 +186,7 @@ describe( 'Exchange FSM', function() {
 
 					exchange.on( 'defined', function() {
 						topology.raise( 'bindings-completed' );
-					} );
+					} ).once();
 
 					return exchange.publish( {} );
 				} );

--- a/spec/behavior/queueFsm.spec.js
+++ b/spec/behavior/queueFsm.spec.js
@@ -48,7 +48,7 @@ describe( 'Queue FSM', function() {
 			queue.on( 'failed', function( err ) {
 				error = err;
 				done();
-			} );
+			} ).once();
 		} );
 
 		it( 'should have failed with an error', function() {
@@ -93,10 +93,10 @@ describe( 'Queue FSM', function() {
 			queue.on( 'failed', function( err ) {
 				error = err;
 				done();
-			} );
+			} ).once();
 			queue.on( 'defined', function() {
 				done();
-			} );
+			} ).once();
 		} );
 
 		it( 'should not have failed', function() {
@@ -121,6 +121,10 @@ describe( 'Queue FSM', function() {
 		} );
 
 		describe( 'when checking in ready state', function() {
+			it( 'should be in ready state', function() {
+				return queue.state.should.equal( 'ready' );
+			} );
+
 			it( 'should resolve check without error', function() {
 				return queue.check().should.be.fulfilled;
 			} );
@@ -132,7 +136,7 @@ describe( 'Queue FSM', function() {
 				channelMock
 					.expects( 'define' )
 					.once()
-					.returns( when.resolve() );
+					.resolves();
 
 				queue.on( 'failed', function( err ) {
 					error = err;
@@ -140,7 +144,7 @@ describe( 'Queue FSM', function() {
 				} );
 				queue.on( 'defined', function() {
 					done();
-				} );
+				} ).once();
 
 				ch.factory().channel.raise( 'released' );
 			} );
@@ -156,7 +160,7 @@ describe( 'Queue FSM', function() {
 				channelMock
 					.expects( 'destroy' )
 					.once()
-					.returns( when.resolve() );
+					.resolves();
 
 				return queue.destroy();
 			} );
@@ -176,10 +180,15 @@ describe( 'Queue FSM', function() {
 					channelMock
 						.expects( 'define' )
 						.once()
-						.returns( when.resolve() );
+						.resolves();
+				} );
+
+				it( 'should be destroyed', function() {
+					return queue.state.should.equal( 'destroyed' );
 				} );
 
 				it( 'should redefine queue without errors', function() {
+					this.timeout( 3000 );
 					return queue.check().should.be.fulfilled;
 				} );
 			} );

--- a/spec/setup.js
+++ b/spec/setup.js
@@ -2,3 +2,4 @@ var chai = require( 'chai' );
 chai.use( require( 'chai-as-promised' ) );
 global.should = chai.should();
 global.sinon = require( 'sinon' );
+require( 'sinon-as-promised' );

--- a/src/ackBatch.js
+++ b/src/ackBatch.js
@@ -1,6 +1,6 @@
 var _ = require( 'lodash' );
 var postal = require( 'postal' );
-var Monologue = require( 'monologue.js' )( _ );
+var Monologue = require( 'monologue.js' );
 var signal = postal.channel( 'rabbit.ack' );
 var log = require( './log.js' )( 'wascally:acknack' );
 
@@ -223,6 +223,6 @@ AckBatch.prototype.listenForSignal = function() {
 	}
 };
 
-Monologue.mixin( AckBatch );
+Monologue.mixInto( AckBatch );
 
 module.exports = AckBatch;

--- a/src/amqp/promiseMachine.js
+++ b/src/amqp/promiseMachine.js
@@ -1,7 +1,7 @@
 var _ = require( 'lodash' );
-var Monologue = require( 'monologue.js' )( _ );
+var Monologue = require( 'monologue.js' );
 var when = require( 'when' );
-var machina = require( 'machina' )( _ );
+var machina = require( 'machina' );
 var log = require( '../log.js' )( 'wascally:iomonad' );
 
 var staticId = 0;
@@ -182,7 +182,7 @@ module.exports = function( factory, target, release, disposalEvent ) {
 		}
 	} );
 
-	Monologue.mixin( PromiseMachine );
+	Monologue.mixInto( PromiseMachine );
 	var machine = new PromiseMachine();
 	_.each( target.prototype, function( prop, name ) {
 		if ( _.isFunction( prop ) ) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 var _ = require( 'lodash' );
-var Monologue = require( 'monologue.js' )( _ );
+var Monologue = require( 'monologue.js' );
 var when = require( 'when' );
 var connectionFn = require( './connectionFsm.js' );
 var topologyFn = require( './topology.js' );
@@ -234,7 +234,7 @@ Broker.prototype.startSubscription = function( queueName, connectionName ) {
 
 require( './config.js' )( Broker );
 
-Monologue.mixin( Broker );
+Monologue.mixInto( Broker );
 
 var broker = new Broker();
 

--- a/src/topology.js
+++ b/src/topology.js
@@ -1,7 +1,7 @@
 var when = require( 'when' );
 var _ = require( 'lodash' );
 var uuid = require( 'node-uuid' );
-var Monologue = require( 'monologue.js' )( _ );
+var Monologue = require( 'monologue.js' );
 var log = require( './log.js' )( 'wascally:topology' );
 var Exchange, Queue;
 var replyId;
@@ -137,7 +137,7 @@ Topology.prototype.createPrimitive = function( Primitive, primitiveType, options
 	var errorFn = function( err ) {
 		return new Error( 'Failed to create ' + primitiveType + ' \'' + options.name +
 			'\' on connection \'' + this.connection.name +
-			'\' with \'' + ( err.message || err ) + '\'' );
+			'\' with \'' + ( err ? ( err.message || err ) : 'N/A' ) + '\'' );
 	}.bind( this );
 	return when.promise( function( resolve, reject ) {
 		var definitions = primitiveType === 'exchange' ? this.definitions.exchanges : this.definitions.queues;
@@ -256,7 +256,7 @@ Topology.prototype.reset = function() {
 	};
 };
 
-Monologue.mixin( Topology );
+Monologue.mixInto( Topology );
 
 module.exports = function( connection, options, unhandledStrategies, exchangeFsm, queueFsm, defaultId ) {
 	// allows us to optionally provide mocks and control the default queue name


### PR DESCRIPTION
 * Bug fix - calling destroy on a queue or exchange should defer until they are in ready state
 * Update machine and monologue versions
 * Remove when.promise and event handles in favor of deferred promises and transitions