### PR TITLE
Including postal envelope header `resolverNoCache`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ PRs with insufficient coverage, broken tests or deviation from the style will no
 PRs should include modified or additional test coverage in both integration and behavioral specs. Integration tests assume RabbitMQ is running on localhost with guest/guest credentials and the consistent hash exchange plugin enabled. You can enable the plugin with the following command:
 
 ```bash
-rabbit-plugins enable rabbitmq_consistent_hash_exchange
+rabbitmq-plugins enable rabbitmq_consistent_hash_exchange
 ```
 
 Running gulp will run both sets after every file change and display a coverage summary. To view a detailed report, run gulp coverage once to bring up the browser.

--- a/src/amqp/queue.js
+++ b/src/amqp/queue.js
@@ -224,7 +224,16 @@ function subscribe( channelName, channel, topology, messages, options ) {
 		};
 
 		if ( raw.fields.routingKey === topology.replyQueue.name ) {
-			responses.publish( correlationId, raw, onPublish );
+			responses.publish(
+				{
+					topic: correlationId,
+					headers: {
+						resolverNoCache: true
+					},
+					data: raw
+				},
+				onPublish
+			);
 		} else {
 			dispatch.publish( raw.type, raw, onPublish );
 		}


### PR DESCRIPTION
This should fix #74. Postal's tests already include test coverage for the `resolverNoCache` option. If you *really* want this to be covered in wascally, let me know (I didn't think it made sense for wascally's to worry about postal's internal cache in its tests).