### PR TITLE
Adding X-Priority Support

### DIFF
--- a/src/amqp/queue.js
+++ b/src/amqp/queue.js
@@ -37,7 +37,6 @@ function define( channel, options, subscriber, connectionName ) {
 			if ( options.limit ) {
 				channel.prefetch( options.limit );
 			}
-
 			if ( options.subscribe ) {
 				subscriber();
 			}

--- a/src/amqp/queue.js
+++ b/src/amqp/queue.js
@@ -31,7 +31,7 @@ function define( channel, options, subscriber, connectionName ) {
 	}
 
 	topLog.info( 'Declaring queue \'%s\' on connection \'%s\' with the options: %s',
-		options.name, connectionName, JSON.stringify( _.omit( options, [ 'name' ] ) ),valid );
+		options.name, connectionName, JSON.stringify( _.omit( options, [ 'name' ] ) ) );
 	return channel.assertQueue( options.name, valid )
 		.then( function( q ) {
 			if ( options.limit ) {

--- a/src/amqp/queue.js
+++ b/src/amqp/queue.js
@@ -24,10 +24,14 @@ function define( channel, options, subscriber, connectionName ) {
 		deadletter: 'deadLetterExchange',
 		deadLetter: 'deadLetterExchange',
 		deadLetterRoutingKey: 'deadLetterRoutingKey',
-		maxPriority: 'x-max-priority'
-	}, 'subscribe', 'limit', 'noBatch' );
+	}, 'subscribe', 'limit', 'noBatch', 'maxPriority' );
+
+	if (options.hasOwnProperty('maxPriority')){
+		valid['arguments']={'x-max-priority': options['maxPriority']};
+	}
+
 	topLog.info( 'Declaring queue \'%s\' on connection \'%s\' with the options: %s',
-		options.name, connectionName, JSON.stringify( _.omit( options, [ 'name' ] ) ) );
+		options.name, connectionName, JSON.stringify( _.omit( options, [ 'name' ] ) ),valid );
 	return channel.assertQueue( options.name, valid )
 		.then( function( q ) {
 			if ( options.limit ) {

--- a/src/amqp/queue.js
+++ b/src/amqp/queue.js
@@ -23,7 +23,8 @@ function define( channel, options, subscriber, connectionName ) {
 		queueLimit: 'maxLength',
 		deadletter: 'deadLetterExchange',
 		deadLetter: 'deadLetterExchange',
-		deadLetterRoutingKey: 'deadLetterRoutingKey'
+		deadLetterRoutingKey: 'deadLetterRoutingKey',
+		maxPriority: 'x-max-priority'
 	}, 'subscribe', 'limit', 'noBatch' );
 	topLog.info( 'Declaring queue \'%s\' on connection \'%s\' with the options: %s',
 		options.name, connectionName, JSON.stringify( _.omit( options, [ 'name' ] ) ) );
@@ -32,6 +33,7 @@ function define( channel, options, subscriber, connectionName ) {
 			if ( options.limit ) {
 				channel.prefetch( options.limit );
 			}
+
 			if ( options.subscribe ) {
 				subscriber();
 			}


### PR DESCRIPTION
As RabbitMQ now natively supports priorities I suggest adding priority support to wascally.
 
