### PR TITLE
Enhancements & Bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage/
 plato/
 .vagrant/
 /Vagrantfile
+tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.2.*
 
+### 0.2.8
+ * Bug fix - Resolve issue #64 working with node-config no longer throws exceptions by avoiding `get` call
+ * Minor improvement to README to better explain publish promises
+
 ### 0.2.7
  * Bug fix - correct memory leak in req/res by leveraging new postal feature
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.2.*
 
 ### Next
+ * No-op duplicate exchange, queue and binding declarations
  * Fall back to routing key if no type is provided for routing
  * Update amqplib dependnecy to 0.4.0 to support Node 4
  * Add explanation of connection events

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.2.*
 
+### Next
+ * Update amqplib dependnecy to 0.4.0 to support Node 4
+
 ### 0.2.8
  * Bug fix - Resolve issue #64 working with node-config no longer throws exceptions by avoiding `get` call
  * Minor improvement to README to better explain publish promises

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ## 0.2.*
 
 ### Next
+ * Fall back to routing key if no type is provided for routing
  * Update amqplib dependnecy to 0.4.0 to support Node 4
+ * Add explanation of connection events
+ * Add test coverage for wildcards in handle
+ * Change log namespaces to use '.' delimiter instead of ':'
 
 ### 0.2.8
  * Bug fix - Resolve issue #64 working with node-config no longer throws exceptions by avoiding `get` call

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 ## 0.2.*
 
 ### Next
- * No-op duplicate exchange, queue and binding declarations
- * Fall back to routing key if no type is provided for routing
- * Update amqplib dependnecy to 0.4.0 to support Node 4
- * Add explanation of connection events
- * Add test coverage for wildcards in handle
+ * #91 - Provide publish timeout
+ * #98 - No-op duplicate exchange, queue and binding declarations
+ * #96 - Fall back to routing key if no type is provided for routing
+ * #94 - Update amqplib dependnecy to 0.4.0 to support Node 4
+ * #77 - Add explanation of connection events
+ * #95 - Add test coverage for wildcards in handle
  * Change log namespaces to use '.' delimiter instead of ':'
 
 ### 0.2.8

--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ The connection object is passed to the event handler for each event. Use the `na
 ## Sending & Receiving Messages
 
 ### Publish
-The publish call returns a promise that is only resolved once the broker has accepted responsibility for the message (see [Publisher Acknowledgments](https://www.rabbitmq.com/confirms.html) for more details). In the rare event that the broker rejects the message, the promise will be rejected. More commonly, the connection to the broker could be lost before the message is confirmed and you end up with a message in "limbo". Wascally keeps a list of unconfirmed messages that have been published _in memory only_. Once a connection is re-established and the topology is in place, Wascally will prioritize re-sending these messages before sending anything else.
+The publish call returns a promise that is only resolved once the broker has accepted responsibility for the message (see [Publisher Acknowledgments](https://www.rabbitmq.com/confirms.html) for more details). If a configured timeout is reached, or in the rare event that the broker rejects the message, the promise will be rejected. More commonly, the connection to the broker could be lost before the message is confirmed and you end up with a message in "limbo". Wascally keeps a list of unconfirmed messages that have been published _in memory only_. Once a connection is re-established and the topology is in place, Wascally will prioritize re-sending these messages before sending anything else.
 
 In the event of a disconnect, all publish promises that have not been resolved are rejected. __This behavior is a problematic over-simplification and subject to change in a future release.__
+
+Publish timeouts can be set per message, per exchange or per connection. The most specific value overrides any set at a higher level. There are no default timeouts set at any level. The timer is started as soon as publish is called and only cancelled once wascally is able to make the publish call on the actual exchange's channel. The timeout is cancelled once publish is called and will not result in a rejected promise due to time spent waiting on a confirmation.
 
 ### publish( exchangeName, options, [connectionName] )
 This syntax uses an options object rather than arguments, here's an example showing all of the available properties:
@@ -63,7 +65,8 @@ rabbit.publish( 'exchange.name', {
 		timestamp: // posix timestamp (long)
 		headers: {
 			'random': 'application specific value'
-		}
+		},
+		timeout: // ms to wait before cancelling the publish and rejecting the promise
 	},
 	connectionName: '' // another optional way to provide connection name if needed
 );
@@ -266,7 +269,8 @@ rabbit.addConnection( {
 	server: '127.0.0.1',
 	port: 5672,
 	timeout: 2000,
-	vhost: '%2f'
+	vhost: '%2f',
+	publishTimeout: undefined // the default timeout in milliseconds for a publish call
 } );
 ```
 
@@ -323,6 +327,7 @@ Options is a hash that can contain the following:
  * durable 			true|false		survive broker restarts
  * persistent 		true|false		a.k.a. persistent delivery, messages saved to disk
  * alternate 		'alt.exchange'	define an alternate exchange
+ * publishTimeout	2^32			timeout in milliseconds for publish calls to this exchange
 
 ### addQueue( queueName, [options], [connectionName] )
 The call returns a promise that can be used to determine when the queue has been created on the server.
@@ -363,7 +368,7 @@ This example shows most of the available options described above.
 			vhost: '%2fmyhost'
 			},
 		exchanges:[
-			{ name: 'config-ex.1', type: 'fanout'  },
+			{ name: 'config-ex.1', type: 'fanout', publishTimeout: 1000 },
 			{ name: 'config-ex.2', type: 'topic', alternate: 'alternate-ex.2', persistent: true },
 			{ name: 'dead-letter-ex.2', type: 'fanout' }
 			],

--- a/README.md
+++ b/README.md
@@ -181,6 +181,35 @@ rabbit.rejectUnhandled();
 
 Starts a consumer on the queue specified. `connectionName` is optional and only required if subscribing to a queue on a connection other than the default one.
 
+## Message Format
+The following structure shows and briefly explains the format of the message that is passed to the handle callback:
+
+```javascript
+{
+	// metadata specific to routing & delivery
+	fields: {
+		consumerTag: "", // identifies the consumer to rabbit
+		deliveryTag: #, // identifies the message delivered for rabbit
+		redelivered: true|false, // indicates if the message was previously nacked or returned to the queue
+		exchange: "" // name of exchange the message was published to,
+		routingKey: "" // the routing key (if any) used when published
+	},
+	properties:{
+		contentType: "application/json", // wascally's default
+		contentEncoding: "utf8", // wascally's default
+		headers: {}, // any user provided headers
+		correlationId: "", // the correlation id if provided
+		replyTo: "", // the reply queue would go here
+		messageId: "", // message id if provided
+		type: "", // the type of the message published
+		appId: "" // not used by wascally
+	},
+	content: { "type": "Buffer", "data": [ ... ] }, // raw buffer of message body
+	body: , // this could be an object, string, etc - whatever was published
+	type: "" // this also contains the type of the message published
+}
+```
+
 ## Message API
 Wascally defaults to (and assumes) queues are in ack mode. It batches ack and nack operations in order to improve total throughput. Ack/Nack calls do not take effect immediately.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,23 @@ This is a very opinionated abstraction over amqplib to help simplify certain com
 # API Reference
 This library implements promises for many of the calls via when.js.
 
+## Connectivity Events
+Wascally emits both generic and specific connectivity events that you can bind to in order to handle various states:
+
+* Any Connection
+ * `connected`
+ * `closed`
+ * `failed`
+* Specific Connection
+ * `[connectionName].connected.opened`
+ * `[connectionName].connected.closed`
+ * `[connectionName].connected.failed`
+
+The connection object is passed to the event handler for each event. Use the `name` property of the connection object to determine which connection the generic events fired for.
+
+> !IMPORTANT! - wascally handles connectivity for you, mucking about with the connection directly isn't supported (don't do it).
+
+
 ## Sending & Receiving Messages
 
 ### Publish

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ This library implements promises for many of the calls via when.js.
 
 ## Sending & Receiving Messages
 
+### Publish
+The publish call returns a promise that is only resolved once the broker has accepted responsibility for the message (see [Publisher Acknowledgments](https://www.rabbitmq.com/confirms.html) for more details). In the rare event that the broker rejects the message, the promise will be rejected. More commonly, the connection to the broker could be lost before the message is confirmed and you end up with a message in "limbo". Wascally keeps a list of unconfirmed messages that have been published _in memory only_. Once a connection is re-established and the topology is in place, Wascally will prioritize re-sending these messages before sending anything else.
+
+In the event of a disconnect, all publish promises that have not been resolved are rejected. __This behavior is a problematic over-simplification and subject to change in a future release.__
+
 ### publish( exchangeName, options, [connectionName] )
 This syntax uses an options object rather than arguments, here's an example showing all of the available properties:
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ rabbit.request( 'request.exchange', {
 
 ### handle( typeName, handler, [context] )
 
-> Handle calls should happen __before__ starting subscriptions.
+> Notes:
+> * Handle calls should happen __before__ starting subscriptions.
+> * The message's routing key will be used if the type is missing or empty on incoming messages
 
 Message handlers are registered to handle a message based on the typeName. Calling handle will return a reference to the handler that can later be removed. The message that is passed to the handler is the raw Rabbit payload. The body property contains the message body published. The message has `ack`, `nack` (requeue the message) and `reject` (don't requeue the message) methods control what Rabbit does with the message.
 

--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ Options is a hash that can contain the following:
  * messageTtl		2^32			time in ms before a message expires on the queue
  * expires			2^32			time in ms before a queue with 0 consumers expires
  * deadLetter 		'dlx.exchange'	the exchange to dead-letter messages to
+ * maxPriority		2^8				the highest priority this queue supports
 
 ### bindExchange( sourceExchange, targetExchange, [routingKeys], [connectionName] )
 Binds the target exchange to the source exchange. Messages flow from source to target.

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "sinon-as-promised": "^3.0.0"
   },
   "dependencies": {
-    "amqplib": "~0.3.0",
+    "amqplib": "~0.4.0",
     "debug": "^2.1.1",
     "lodash": "~2.4.1",
     "machina": "~1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wascally",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Abstractions to simplify working with the wascally wabbitMQ",
   "main": "src/index.js",
   "repository": "https://github.com/leankit-labs/wascally",

--- a/spec/behavior/connection.spec.js
+++ b/spec/behavior/connection.spec.js
@@ -42,6 +42,20 @@ var connectionMonadFn = function() {
 
 describe( 'Connection FSM', function() {
 
+	describe( 'when configuration has getter', function() {
+		it( 'should not throw exception', function() {
+			expect( function() {
+				connectionFn( { get: function( property ) {
+					var value = this[ property ];
+					if (value === undefined) {
+						throw new Error('Configuration property "' + property + '" is not defined');
+					}
+					return value;
+				} } );
+			} ).to.not.throw( Error );
+		} );
+	} );
+
 	describe( 'when connection is unavailable (failed)', function() {
 
 		describe( 'when connecting', function() {

--- a/spec/behavior/topology.spec.js
+++ b/spec/behavior/topology.spec.js
@@ -588,7 +588,7 @@ describe( 'Topology', function() {
 			} );
 		} );
 
-		describe( 'when attempting to create an queue', function() {
+		describe( 'when attempting to create a queue', function() {
 			var topology, conn, error, ex, q;
 
 			before( function() {

--- a/spec/behavior/topology.spec.js
+++ b/spec/behavior/topology.spec.js
@@ -267,6 +267,50 @@ describe( 'Topology', function() {
 		} );
 	} );
 
+	describe( 'when creating a duplicate exchange', function() {
+		var topology, conn, exchange, ex, q;
+		var calls = 0;
+
+		before( function( done ) {
+			ex = emitter();
+			q = emitter();
+			ex.check = function() {
+				ex.raise( 'defined' );
+				return when.resolve();
+			};
+			var Exchange = function() {
+				calls = calls + 1;
+				return ex;
+			};
+			var Queue = function() {
+				return q;
+			};
+			conn = connectionFn();
+			topology = topologyFn( conn.instance, {}, undefined, Exchange, Queue );
+			topology.createExchange( { name: 'noice' } );
+			topology.createExchange( { name: 'noice' } )
+				.then( function( created ) {
+					exchange = created;
+					done();
+				} );
+			process.nextTick( function() {
+				ex.raise( 'defined' );
+			} );
+		} );
+
+		it( 'should create exchange', function() {
+			exchange.should.eql( ex );
+		} );
+
+		it( 'should not create duplicate exchanges', function() {
+			calls.should.equal( 1 );
+		} );
+
+		it( 'should add exchange to channels', function() {
+			should.exist( topology.channels[ 'exchange:noice' ] );
+		} );
+	} );
+
 	describe( 'when creating invalid exchange', function() {
 		var topology, conn, error, ex, q;
 

--- a/spec/integration/integration.spec.js
+++ b/spec/integration/integration.spec.js
@@ -74,12 +74,22 @@ describe( 'Integration Test Suite', function() {
 
 				rabbit.addConnection( {
 					name: 'silly',
-					server: 'shfifty-five.gov'
+					server: 'shfifty-five.gov',
+					publishTimeout: 50
 				} );
+
+				rabbit.addExchange( { name: 'silly-ex' }, 'silly' );
 			} );
 
 			it( 'should fail to connect', function() {
 				error.should.equal( 'No endpoints could be reached' );
+			} );
+
+			it( 'should reject publish after timeout', function() {
+				return rabbit.publish( 'silly-ex', { body: 'test' }, 'silly' )
+					.then( null, function( err ) {
+						console.log( err );
+					} );
 			} );
 
 			after( function() {
@@ -503,8 +513,6 @@ describe( 'Integration Test Suite', function() {
 			harness.clean();
 		} );
 	} );
-
-
 
 	after( function() {
 		this.timeout( 5000 );

--- a/spec/integration/integration.spec.js
+++ b/spec/integration/integration.spec.js
@@ -478,6 +478,33 @@ describe( 'Integration Test Suite', function() {
 		} );
 	} );
 
+	describe( 'with no type present', function() {
+		var harness;
+		before( function( done ) {
+			harness = harnessFn( done, 1 );
+			harness.handle( '#.typeless' );
+			rabbit.publish( 'wascally-ex.topic', { type: '', routingKey: 'this.is.typeless', body: 'one' } );
+		} );
+
+		it( 'should handle based on topic', function() {
+			var results = _.map( harness.received, function( m ) {
+				return {
+					body: m.body,
+					key: m.fields.routingKey
+				};
+			} );
+			_.sortBy( results, 'body' ).should.eql(
+				[
+					{ body: 'one', key: 'this.is.typeless' }
+				] );
+		} );
+
+		after( function() {
+			harness.clean();
+		} );
+	} );
+
+
 
 	after( function() {
 		this.timeout( 5000 );

--- a/spec/setup.js
+++ b/spec/setup.js
@@ -1,5 +1,6 @@
 var chai = require( 'chai' );
 chai.use( require( 'chai-as-promised' ) );
 global.should = chai.should();
+global.expect = chai.expect;
 global.sinon = require( 'sinon' );
 require( 'sinon-as-promised' );

--- a/src/ackBatch.js
+++ b/src/ackBatch.js
@@ -2,7 +2,7 @@ var _ = require( 'lodash' );
 var postal = require( 'postal' );
 var Monologue = require( 'monologue.js' );
 var signal = postal.channel( 'rabbit.ack' );
-var log = require( './log.js' )( 'wascally:acknack' );
+var log = require( './log.js' )( 'wascally.acknack' );
 
 var calls = {
 	ack: '_ack',

--- a/src/amqp/connection.js
+++ b/src/amqp/connection.js
@@ -4,7 +4,7 @@ var fs = require( 'fs' );
 var when = require( 'when' );
 var AmqpConnection = require( 'amqplib/lib/callback_model' ).CallbackModel;
 var promiseFn = require( './promiseMachine.js' );
-var log = require( '../log.js' )( 'wascally:amqp-connection' );
+var log = require( '../log.js' )( 'wascally.amqp-connection' );
 
 function getArgs( fn ) {
 	var fnString = fn.toString();

--- a/src/amqp/connection.js
+++ b/src/amqp/connection.js
@@ -6,8 +6,15 @@ var AmqpConnection = require( 'amqplib/lib/callback_model' ).CallbackModel;
 var promiseFn = require( './promiseMachine.js' );
 var log = require( '../log.js' )( 'wascally:amqp-connection' );
 
+function getArgs( fn ) {
+	var fnString = fn.toString();
+	return _.map( /[(]([^)]*)[)]/.exec( fnString )[ 1 ].split( ',' ), function( x ) {
+		return String.prototype.trim.bind( x )();
+	} );
+}
+
 function getOption( opts, key, alt ) {
-	if ( opts.get ) {
+	if ( opts.get && supportsDefaults( opts.get ) ) {
 		return opts.get( key, alt );
 	} else {
 		return opts[ key ] || alt;
@@ -28,6 +35,10 @@ function split( x ) {
 	} else {
 		return x.split( ',' ).map( trim );
 	}
+}
+
+function supportsDefaults( opts ) {
+	return opts.get && getArgs( opts.get ).length > 1;
 }
 
 function trim( x ) {

--- a/src/amqp/exchange.js
+++ b/src/amqp/exchange.js
@@ -14,7 +14,7 @@ function aliasOptions( options, aliases ) {
 function define( channel, options, connectionName ) {
 	var valid = aliasOptions( options, {
 		alternate: 'alternateExchange'
-	}, 'persistent' );
+	}, 'persistent', 'publishTimeout' );
 	topLog.info( 'Declaring %s exchange \'%s\' on connection \'%s\' with the options: %s',
 		options.type,
 		options.name,
@@ -69,20 +69,23 @@ function publish( channel, options, topology, log, message ) {
 		channelName,
 		topology.connection.name );
 
-	return channel.publish(
-		channelName,
-		effectiveKey,
-		payload,
-		publishOptions
-		)
-		.then( function() {
-			log.remove( message );
-		} );
+	function remove( x ) {
+		log.remove( message );
+		return x;
+	}
+
+	return when.promise( function( resolve, reject ) {
+		channel.publish(
+			channelName,
+			effectiveKey,
+			payload,
+			publishOptions
+		).then( resolve, reject );
+	} ).then( remove, remove );
 }
 
 module.exports = function( options, topology, publishLog ) {
 	var channel = getChannel( topology.connection );
-
 	return {
 		channel: channel,
 		define: define.bind( undefined, channel, options, topology.connection.name ),

--- a/src/amqp/exchange.js
+++ b/src/amqp/exchange.js
@@ -1,7 +1,7 @@
 var _ = require( 'lodash' );
 var when = require( 'when' );
-var exLog = require( '../log.js' )( 'wascally:exchange' );
-var topLog = require( '../log.js' )( 'wascally:topology' );
+var exLog = require( '../log.js' )( 'wascally.exchange' );
+var topLog = require( '../log.js' )( 'wascally.topology' );
 
 function aliasOptions( options, aliases ) {
 	var aliased = _.transform( options, function( result, value, key ) {

--- a/src/amqp/promiseMachine.js
+++ b/src/amqp/promiseMachine.js
@@ -2,7 +2,7 @@ var _ = require( 'lodash' );
 var Monologue = require( 'monologue.js' );
 var when = require( 'when' );
 var machina = require( 'machina' );
-var log = require( '../log.js' )( 'wascally:iomonad' );
+var log = require( '../log.js' )( 'wascally.iomonad' );
 
 var staticId = 0;
 

--- a/src/amqp/queue.js
+++ b/src/amqp/queue.js
@@ -201,7 +201,7 @@ function subscribe( channelName, channel, topology, messages, options ) {
 		raw.nack = ops.nack;
 		raw.reject = ops.reject;
 		raw.reply = getReply( channel, raw, topology.replyQueue.name, topology.connection.name );
-		raw.type = raw.properties.type;
+		raw.type = _.isEmpty( raw.properties.type ) ? raw.fields.routingKey : raw.properties.type;
 
 		var onPublish = function( data ) {
 			var handled;

--- a/src/amqp/queue.js
+++ b/src/amqp/queue.js
@@ -4,9 +4,9 @@ var postal = require( 'postal' );
 var dispatch = postal.channel( 'rabbit.dispatch' );
 var responses = postal.channel( 'rabbit.responses' );
 var when = require( 'when' );
-var log = require( '../log.js' )( 'wascally:amqp-queue' );
-var topLog = require( '../log.js' )( 'wascally:topology' );
-var unhandledLog = require( '../log.js' )( 'wascally:unhandled' );
+var log = require( '../log.js' )( 'wascally.amqp-queue' );
+var topLog = require( '../log.js' )( 'wascally.topology' );
+var unhandledLog = require( '../log.js' )( 'wascally.unhandled' );
 var noOp = function() {};
 
 function aliasOptions( options, aliases ) {

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,5 @@
 var when = require( 'when' );
-var log = require( './log' )( 'wascally:configuration' );
+var log = require( './log' )( 'wascally.configuration' );
 
 module.exports = function( Broker ) {
 

--- a/src/connectionFsm.js
+++ b/src/connectionFsm.js
@@ -2,7 +2,7 @@ var _ = require( 'lodash' );
 var Monologue = require( 'monologue.js' );
 var when = require( 'when' );
 var machina = require( 'machina' );
-var log = require( './log.js' )( 'wascally:connection' );
+var log = require( './log.js' )( 'wascally.connection' );
 
 var Connection = function( options, connectionFn, channelFn ) {
 	channelFn = channelFn || require( './amqp/channel' );

--- a/src/exchangeFsm.js
+++ b/src/exchangeFsm.js
@@ -67,7 +67,16 @@ var Channel = function( options, connection, topology, channelFn ) {
 
 		publish: function( message ) {
 			exLog.info( 'Publish called in state', this.state );
+			var publishTimeout = message.timeout || options.publishTimeout || message.connectionPublishTimeout || 0;
 			return when.promise( function( resolve, reject ) {
+				var timeout, timedOut;
+				if( publishTimeout > 0 ) {
+					timeout = setTimeout( function() {
+						timedOut = true;
+						reject( new Error( 'Publish took longer than configured timeout' ) );
+						this._removeDeferred( reject );
+					}.bind( this ), publishTimeout );
+				}
 				function onPublished() {
 					resolve();
 					this._removeDeferred( reject );
@@ -77,8 +86,14 @@ var Channel = function( options, connection, topology, channelFn ) {
 					this._removeDeferred( reject );
 				}
 				var op = function() {
-					return this.channel.publish( message )
-						.then( onPublished.bind( this ), onRejected.bind( this ) );
+					if( timeout ) {
+						clearTimeout( timeout );
+						timeout = null;
+					}
+					if( !timedOut ) {
+						return this.channel.publish( message )
+							.then( onPublished.bind( this ), onRejected.bind( this ) );
+					}
 				}.bind( this );
 				this.deferred.push( reject );
 				this.handle( 'publish', op );

--- a/src/exchangeFsm.js
+++ b/src/exchangeFsm.js
@@ -3,7 +3,7 @@ var when = require( 'when' );
 var machina = require( 'machina' );
 var Monologue = require( 'monologue.js' );
 var publishLog = require( './publishLog' );
-var exLog = require( './log.js' )( 'wascally:exchange' );
+var exLog = require( './log.js' )( 'wascally.exchange' );
 
 var Channel = function( options, connection, topology, channelFn ) {
 

--- a/src/index.js
+++ b/src/index.js
@@ -40,9 +40,11 @@ Broker.prototype.addConnection = function( options ) {
 			this.emit( connection.name + '.connection.opened', connection );
 		}.bind( this ) );
 		connection.on( 'closed', function() {
+			this.emit( 'closed', connection );
 			this.emit( connection.name + '.connection.closed', connection );
 		}.bind( this ) );
 		connection.on( 'failed', function( err ) {
+			this.emit( 'failed', connection );
 			this.emit( name + '.connection.failed', err );
 		}.bind( this ) );
 		this.connections[ name ] = topology;

--- a/src/index.js
+++ b/src/index.js
@@ -187,6 +187,10 @@ Broker.prototype.publish = function( exchangeName, type, message, routingKey, co
 			connectionName: connectionName
 		};
 	}
+	var connection = this.connections[ connectionName ].options;
+	if( connection.publishTimeout ) {
+		options.connectionPublishTimeout = connection.publishTimeout;
+	}
 	return this.getExchange( exchangeName, connectionName )
 		.publish( options );
 };

--- a/src/queueFsm.js
+++ b/src/queueFsm.js
@@ -3,7 +3,7 @@ var when = require( 'when' );
 var machina = require( 'machina' );
 var Monologue = require( 'monologue.js' );
 Monologue.mixInto( machina.Fsm );
-var log = require( './log.js' )( 'wascally:queue' );
+var log = require( './log.js' )( 'wascally.queue' );
 
 var Channel = function( options, connection, topology, channelFn ) {
 

--- a/src/topology.js
+++ b/src/topology.js
@@ -41,6 +41,7 @@ var Topology = function( connection, options, unhandledStrategies ) {
 		exchanges: {},
 		queues: {}
 	};
+	this.options = options;
 	this.replyQueue = { name: false };
 	this.onUnhandled = function( message ) {
 		return unhandledStrategies.onUnhandled( message );

--- a/src/topology.js
+++ b/src/topology.js
@@ -2,7 +2,7 @@ var when = require( 'when' );
 var _ = require( 'lodash' );
 var uuid = require( 'node-uuid' );
 var Monologue = require( 'monologue.js' );
-var log = require( './log.js' )( 'wascally:topology' );
+var log = require( './log.js' )( 'wascally.topology' );
 var Exchange, Queue;
 var replyId;
 


### PR DESCRIPTION
 * #91 - Provide publish timeout
 * #98 - No-op duplicate exchange, queue and binding declarations
 * #96 - Fall back to routing key if no type is provided for routing
 * #94 - Update amqplib dependnecy to 0.4.0 to support Node 4
 * #77 - Add explanation of connection events
 * #95 - Add test coverage for wildcards in handle
 * Change log namespaces to use '.' delimiter instead of ':'