### PR TITLE
Change pubsub demo credentials to guest/guest

### DIFF
--- a/demo/pubsub/topology.js
+++ b/demo/pubsub/topology.js
@@ -2,8 +2,8 @@ module.exports = function( rabbit, subscribeTo ) {
 	return rabbit.configure( {
 		// arguments used to establish a connection to a broker
 		connection: {
-			user: 'bunneh',
-			pass: 'rabbit',
+			user: 'guest',
+			pass: 'guest',
 			server: [ '127.0.0.1' ],
 			port: 5672,
 			vhost: '%2f',


### PR DESCRIPTION
This allows it to work out of the box with the RabbitMQ Docker image.