### PR TITLE
Add "verbatim" option to subscribe function

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ The following structure shows and briefly explains the format of the message tha
 	},
 	content: { "type": "Buffer", "data": [ ... ] }, // raw buffer of message body
 	body: , // this could be an object, string, etc - whatever was published
+	        // if the queue was configured with the noParse option, it will be a string
 	type: "" // this also contains the type of the message published
 }
 ```
@@ -393,14 +394,22 @@ This example shows most of the available options described above.
 			{ name: 'config-ex.1', type: 'fanout', publishTimeout: 1000 },
 			{ name: 'config-ex.2', type: 'topic', alternate: 'alternate-ex.2', persistent: true },
 			{ name: 'dead-letter-ex.2', type: 'fanout' }
+			{ name: 'config-ex.3', type: 'fanout', publishTimeout: 1000 },
 			],
 		queues:[
 			{ name:'config-q.1', limit: 100, queueLimit: 1000 },
 			{ name:'config-q.2', subscribe: true, deadLetter: 'dead-letter-ex.2' }
+			{
+				name:'config-q.3',
+				limit: 100,
+				queueLimit: 1000,
+				noParse: true // message bodies will NOT be parsed as JSON
+			},
 			],
 		bindings:[
 			{ exchange: 'config-ex.1', target: 'config-q.1', keys: [ 'bob','fred' ] },
 			{ exchange: 'config-ex.2', target: 'config-q.2', keys: 'test1' }
+			{ exchange: 'config-ex.3', target: 'config-q.3', keys: 'test1' }
 		]
 	};
 ```

--- a/spec/integration/alt-configuration.js
+++ b/spec/integration/alt-configuration.js
@@ -10,6 +10,11 @@ module.exports = {
 	},
 	exchanges: [
 		{
+			name: 'noreply-ex.direct.noParse',
+			type: 'direct',
+			autoDelete: true
+		},
+		{
 			name: 'noreply-ex.direct',
 			type: 'direct',
 			autoDelete: true
@@ -18,6 +23,12 @@ module.exports = {
 
 	queues: [
 		{
+			name: 'noreply-q.direct.noParse',
+			autoDelete: true,
+			noParse: true,
+			subscribe: true
+		},
+		{
 			name: 'noreply-q.direct',
 			autoDelete: true,
 			subscribe: true
@@ -25,6 +36,11 @@ module.exports = {
 	],
 
 	bindings: [
+		{
+			exchange: 'noreply-ex.direct.noParse',
+			target: 'noreply-q.direct.noParse',
+			keys: ''
+		},
 		{
 			exchange: 'noreply-ex.direct',
 			target: 'noreply-q.direct',

--- a/src/amqp/queue.js
+++ b/src/amqp/queue.js
@@ -193,7 +193,12 @@ function subscribe( channelName, channel, topology, messages, options ) {
 	log.info( 'Starting subscription %s - %s', channelName, topology.connection.name );
 	return channel.consume( channelName, function( raw ) {
 		var correlationId = raw.properties.correlationId;
-		raw.body = JSON.parse( raw.content.toString( 'utf8' ) );
+		var contentString = raw.content.toString( 'utf8' );
+		if ( options.noParse ) {
+			raw.body = contentString;
+		} else {
+			raw.body = JSON.parse( contentString );
+		}
 
 		var ops = getResolutionOperations( channel, raw, messages, options );
 


### PR DESCRIPTION
My use case involves consuming non-JSON messages sent by another client. I realize that "JSON as the only serialization provider" is one of this library's assumptions, but I'm hoping it can be made possible to bypass the JSON parsing if needed. I wasn't sure of exactly the right place to put this option, so I wanted to post what I have so far (still needs docs/tests) and get some feedback. What do you think?