### PR TITLE
Added check if headers existed on reply

### DIFF
--- a/src/amqp/queue.js
+++ b/src/amqp/queue.js
@@ -105,7 +105,7 @@ function getReply( channel, raw, replyQueue, connectionName ) {
 				replyTo,
 				connectionName,
 				publishOptions.type );
-			if ( raw.properties.headers[ 'direct-reply-to' ] ) {
+			if ( raw.properties.headers && raw.properties.headers[ 'direct-reply-to' ] ) {
 				return channel.publish(
 					'',
 					replyTo,


### PR DESCRIPTION
In trying to hook up a C# requester to our Node responder, we came across the issue of:

`Potentially unhandled rejection [10] TypeError: Cannot read property 'direct-reply-to' of undefined
    at Object.reply (/usr/src/app/node_modules/wascally/src/amqp/queue.js:108:31)`

Adding this additional check allowed the two to communicate properly.
